### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go install -ldflags "-X main.Version=${GFD_VERSION}" github.com/NVIDIA/gpu-f
 
 RUN go test .
 
-FROM nvidia/cuda
+FROM fedora-minimal
 
 COPY --from=build /go/bin/gpu-feature-discovery /usr/bin/gpu-feature-discovery
 


### PR DESCRIPTION
Is a cuda image really needed to run gpu-feature-discovery?  You're only using the nvmlInterface and this lib is provided by the prestart hook. 
Any obvious reason I am missing? 
BTW why did you disable issues?