### PR TITLE
Helm chart - changed priorityClass as a variable

### DIFF
--- a/deployments/helm/gpu-feature-discovery/templates/daemonset.yml
+++ b/deployments/helm/gpu-feature-discovery/templates/daemonset.yml
@@ -38,7 +38,9 @@ spec:
       # scheduler reserves resources for critical add-on pods so that they can
       # be rescheduled after a failure.
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-      priorityClassName: "system-node-critical"
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/gpu-feature-discovery/values.yaml
+++ b/deployments/helm/gpu-feature-discovery/values.yaml
@@ -8,6 +8,8 @@ fullnameOverride: ""
 
 namespace: node-feature-discovery
 
+priorityClassName: "system-node-critical"
+
 imagePullSecrets: []
 image:
   repository: nvcr.io/nvidia/gpu-feature-discovery
@@ -38,4 +40,3 @@ node-feature-discovery:
         pci:
           deviceLabelFields:
             - vendor
-


### PR DESCRIPTION
I'm trying to deploy the gpu-feature-discovery using the provided helm chart but due to the pod priority admission plugin in EKS the pods with `system-node-critical` cannot be scheduled outside of `kube-system` namespace. I've found some details about this [here](https://github.com/kubernetes/kubernetes/issues/78383) .
I thought I'll create this PR maybe it can be approved.
Thanks