### PR TITLE
Don't label product name or memory if more than one product type present 

### DIFF
--- a/mig-strategy.go
+++ b/mig-strategy.go
@@ -61,11 +61,6 @@ func (s *migStrategyNone) GenerateLabels() (map[string]string, error) {
 		return nil, fmt.Errorf("Error getting device count: %v", err)
 	}
 
-	device, err := s.nvml.NewDevice(0)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting device: %v", err)
-	}
-
 	labels := make(map[string]string)
 	labels["nvidia.com/gpu.count"] = fmt.Sprintf("%d", count)
 
@@ -73,6 +68,11 @@ func (s *migStrategyNone) GenerateLabels() (map[string]string, error) {
 	if err != nil {
 		log.Printf("%v", err)
 		return labels, nil
+	}
+
+	device, err := s.nvml.NewDevice(0)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting device: %v", err)
 	}
 
 	if device.Instance().Model != nil {

--- a/mig-strategy_test.go
+++ b/mig-strategy_test.go
@@ -80,6 +80,34 @@ func TestNoneStrategyReturnsOnlyCountLabelForTwoNonIdenticalDevices(t *testing.T
 	require.Len(t, labels, 1)
 }
 
+func TestNoneStrategyReturnsWorkingDeviceWhenOneModelNil(t *testing.T) {
+	nvmlMock := NewTestNvmlMock()
+	nvmlMock.devices = append(nvmlMock.devices, nvmlMock.devices[0])
+
+	model1 := "MOCKMODEL256"
+	mem1   := uint64(256)
+
+	nvmlMock.devices = []NvmlMockDevice{
+		NvmlMockDevice{
+			instance: &nvml.Device{Model: nil, Memory: nil},
+			attributes: &nvml.DeviceAttributes{},
+		},
+		NvmlMockDevice{
+			instance: &nvml.Device{Model: &model1, Memory: &mem1},
+			attributes: &nvml.DeviceAttributes{},
+		},
+	}
+
+	none, _ := NewMigStrategy(MigStrategyNone, nvmlMock)
+	labels, err := none.GenerateLabels()
+
+	require.NoError(t, err)
+	require.Equal(t, "MOCKMODEL256", labels["nvidia.com/gpu.product"], "Incorrect label nvidia.com/gpu.product")
+	require.Equal(t, "256", labels["nvidia.com/gpu.memory"], "Incorrect label nvidia.com/gpu.memory")
+	require.Equal(t, "2", labels["nvidia.com/gpu.count"], "Incorrect label nvidia.com/gpu.count")
+	require.Len(t, labels, 3)
+}
+
 func TestSingleStrategyReturnsNoneForSingleDeviceMigDisabled(t *testing.T) {
 	nvmlMock := NewTestNvmlMock()
 


### PR DESCRIPTION
Currently, gpu-feature-discovery assumes that all GPUs attached to a node are identical. Sadly this assumption isn't valid for a few of our nodes. These nodes have a mix of 16GB and 32GB V100s. Gpu-feature-discovery only examines the first GPU, so will label our mixed nodes as having 32GB if the first GPU does, regardless of other GPUs.

This PR examines all GPUs, and doesn't label product type or memory if there is more than one distinct product types. Users who don't care about these details can still match against the node, and those that do care won't.
