### PR TITLE
Fixed helm template indentation for resources to function

### DIFF
--- a/deployments/helm/gpu-feature-discovery/templates/daemonset.yml
+++ b/deployments/helm/gpu-feature-discovery/templates/daemonset.yml
@@ -77,7 +77,7 @@ spec:
               mountPath: "/sys/class/dmi/id/product_name"
           {{- with .Values.resources }}
           resources:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
         - name: output-dir


### PR DESCRIPTION
If defining `resources: {}` the indent was one level above where it needed to be to function properly. "limits" and "requests" were inline with the "resources:" definition.