### PR TITLE
chore: update values file for flexibility in nodeSelector map

### DIFF
--- a/deployments/helm/gpu-feature-discovery/values.yaml
+++ b/deployments/helm/gpu-feature-discovery/values.yaml
@@ -22,14 +22,23 @@ securityContext:
 resources: {}
 affinity: {}
 tolerations: {}
-nodeSelector:
-  feature.node.kubernetes.io/pci-10de.present: "true" # NVIDIA vendor ID
 
+# if nfd.deploy=true (or if node-feature-discovery is deployed another way) use this nodeSelector
+# to deploy the daemonset only on nodes with the right pci vendor id
+# you can do so by uncommenting the line below and remove the `{}`.
+nodeSelector: {}
+#  feature.node.kubernetes.io/pci-10de.present: "true" # NVIDIA vendor ID
+
+# Enable to true if you wish to deploy the node-feature-discovery tool to label nodes with gpu feature label(s).
+# The daemonset will attach to those nodes if the nodeSelector field is given that (those) feature label(s).
 nfd:
-  deploy: true
+  deploy: false
 
 node-feature-discovery:
   master:
+    # Required to have labels written to nodes, otherwise you will not see the labels
+    # if you have already installed nfd, make sure to add these labels to that deployment
+    # so that nvidia labels can be applied.
     extraLabelNs:
       - nvidia.com
   worker:


### PR DESCRIPTION
In this PR I try to be a bit more descriptive in a few key points of the values file for the helm chart.
My main concern is the way that the nodeSelector is set for the values file in the chart. Although most things get overridden when a user uses their own values file, maps are merged, so a user can end up with the following result:

```
      nodeSelector:
        feature.node.kubernetes.io/pci-10de.present: "true"
        feature.node.kubernetes.io/pci-0302_10de.present: "true"
```

which would not be what they expected. Here we resolve this by allowing it to be empty and only filled in when the users wishes it to. It is true that this would remove the "default" behavior of this chart, but I would suggest that we should reconsider the default and supply a suggested values file for the project. I can help with this if you would like. Thank you!