### PR TITLE
Add runtimeClassName to helm chart matching nvidia-device-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ of customizable values. The most commonly overridden ones are:
   nfd.deploy:
       When set to true, deploy NFD as a subchart with all of the proper
       parameters set for it (default "true")
-
+  runtimeClassName:
+      the runtimeClassName to use, for use with clusters that have multiple runtimes
 ```
 
 **Note:** The following document provides more information on the available MIG

--- a/deployments/helm/gpu-feature-discovery/templates/daemonset.yml
+++ b/deployments/helm/gpu-feature-discovery/templates/daemonset.yml
@@ -39,6 +39,9 @@ spec:
       # be rescheduled after a failure.
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/gpu-feature-discovery/values.yaml
+++ b/deployments/helm/gpu-feature-discovery/values.yaml
@@ -25,6 +25,8 @@ tolerations: {}
 nodeSelector:
   feature.node.kubernetes.io/pci-10de.present: "true" # NVIDIA vendor ID
 
+runtimeClassName: null
+
 nfd:
   deploy: true
 


### PR DESCRIPTION
Providing the same abilities and matching how it's done in nvidia-device-plugin: https://github.com/NVIDIA/k8s-device-plugin/commit/70df588390e604bf2485ea3bb513b7376f3e9bf1

Signed-off-by: Damon Maria <damon@mindhive.co.nz>