### PR TITLE
Fix create permission error when nodefeature enabled

### DIFF
--- a/deployments/helm/gpu-feature-discovery/templates/rbac.yaml
+++ b/deployments/helm/gpu-feature-discovery/templates/rbac.yaml
@@ -18,6 +18,7 @@ rules:
   - get
   - list
   - watch
+  - create
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
When enabling nodefeature in chart settings, get an error as below.
Need to add create permission in Role.

```
failed to create NodeFeature object "nvidia-features-for-node-gpu01": 
nodefeatures.nfd.k8s-sigs.io is forbidden: User "system:serviceaccount:node-feature-discovery:gpu-feature-discovery" cannot create resource "nodefeatures" in API group "nfd.k8s-sigs.io" in the namespace "node-feature-discovery"
```